### PR TITLE
Add/Check migrationNeeded flag for eol pots

### DIFF
--- a/src/config/vault/bsc.js
+++ b/src/config/vault/bsc.js
@@ -46,6 +46,7 @@ export const pools = [
 		sponsorToken: 'BIFI',
 		sponsorAddress: '0xCa3F508B8e4Dd382eE878A314789373D80A5190A',
 		sponsorTokenDecimals: 18,
+		migrationNeeded: true,
 		migrationContractAddress: '0x30d55CE74E2dcd1B0Ff37214a6978FCFc06aA499',
 		migrationRewardAddress: '0x9273be9c180B0271cc2c90E5BF99477B573Fe904',
 		migrationLearnMoreUrl: 'https://moonpot.com/alpha/learn/how-to-move-cake-from-the-retired-cake-moonpot/',

--- a/src/features/home/components/MigrationNotices/MigrationNotices.js
+++ b/src/features/home/components/MigrationNotices/MigrationNotices.js
@@ -44,20 +44,20 @@ export function MigrationNotices({sortConfig}) {
 	const allPots = useSelector(state => state.vaultReducer.pools);
 	const dispatch = useDispatch();
 
-	const eolPots = useMemo(() => {
-		return Object.values(allPots).filter(pot => pot.status === 'eol' && pot.vaultType === potType && pot.network === currentNetwork);
+	const potsNeedingMigration = useMemo(() => {
+		return Object.values(allPots).filter(pot => pot.status === 'eol' && pot.vaultType === potType && pot.network === currentNetwork && pot.migrationNeeded);
 	}, [potType, allPots, currentNetwork]);
-	const hasEolPots = eolPots.length > 0;
+	const hasPotsNeedingMigration = potsNeedingMigration.length > 0;
 
 	useEffect(() => {
-		if (currentAddress && hasEolPots) {
+		if (currentAddress && hasPotsNeedingMigration) {
 			dispatch(reduxActions.balance.fetchBalances());
 		}
-	}, [dispatch, currentAddress, hasEolPots]);
+	}, [dispatch, currentAddress, hasPotsNeedingMigration]);
 
-	if (currentAddress && hasEolPots) {
+	if (currentAddress && hasPotsNeedingMigration) {
 		return (
-			<div className={classes.notices}>{eolPots.map(pot => (<MigrationNotice key={pot.id} pot={pot}/>))}</div>);
+			<div className={classes.notices}>{potsNeedingMigration.map(pot => (<MigrationNotice key={pot.id} pot={pot}/>))}</div>);
 	}
 
 	return null;


### PR DESCRIPTION
With the 2nd pot now being marked as 'eol', it was showing migration needed notice for this pot also.

Added a flag of `migrationNeeded: true` to the `cake-bifi` pot and changed logic of `MigrationNotices` to additionally check for this flag.