### PR TITLE
Fix "Bonus Earnings" Section Padding

### DIFF
--- a/src/features/dashboard/dashboard.js
+++ b/src/features/dashboard/dashboard.js
@@ -362,22 +362,22 @@ const Dashboard = () => {
                                                         <AnimateHeight duration={ 500 } height={ bonusOpen ? 'auto' : 0 }>
                                                             <Grid container>
                                                                 <Grid item xs={6}>
-                                                                    <Typography className={classes.myDetailsText} align={'left'}>
+                                                                    <Typography className={classes.myDetailsText} align={'left'} style={{marginBottom: 0}}>
                                                                         <Trans i18nKey="myBonusEarnings"/>
                                                                     </Typography>
                                                                 </Grid>
                                                                 <Grid item xs={6}>
-                                                                    <Typography className={classes.myDetailsValue} align={'right'}>{formatDecimals(item.earned)} {item.sponsorToken} (${formatDecimals(item.earned.multipliedBy(prices.prices[item.sponsorToken]),2)})</Typography>
+                                                                    <Typography className={classes.myDetailsValue} align={'right'} style={{marginBottom: 0}}>{formatDecimals(item.earned)} {item.sponsorToken} (${formatDecimals(item.earned.multipliedBy(prices.prices[item.sponsorToken]),2)})</Typography>
                                                                 </Grid>
                                                                 { item.boostToken ? 
                                                                 <React.Fragment>
                                                                     <Grid item xs={6}>
-                                                                        <Typography className={classes.myDetailsText} align={'left'}>
+                                                                        <Typography className={classes.myDetailsText} align={'left'} style={{marginTop: '16px'}}>
                                                                             <Trans i18nKey="myBoostEarnings"/>
                                                                         </Typography>
                                                                     </Grid>
                                                                     <Grid item xs={6}>
-                                                                        <Typography className={classes.myDetailsValue} align={'right'}>{formatDecimals(item.boosted)} {item.boostToken} (${formatDecimals(item.boosted.multipliedBy(prices.prices[item.boostToken]), 2)})</Typography>
+                                                                        <Typography className={classes.myDetailsValue} align={'right'} style={{marginTop: '16px'}}>{formatDecimals(item.boosted)} {item.boostToken} (${formatDecimals(item.boosted.multipliedBy(prices.prices[item.boostToken]), 2)})</Typography>
                                                                     </Grid>
                                                                     <Grid item xs={12}>
                                                                         <Typography className={classes.myPotsInfoText} align={'left'}>

--- a/src/features/dashboard/styles.js
+++ b/src/features/dashboard/styles.js
@@ -272,7 +272,7 @@ const styles = (theme) => ({
         lineHeight: '139%',
         letterSpacing: '0.2px',
         color: 'rgba(54, 117, 162, 0.4)',
-        margin: '16px 0 8px 0',
+        margin: '20px 0 16px 0',
     },
     depositMoreExtraInfo: {
         fontWeight: 400,


### PR DESCRIPTION
-Fixed a issue with padding of the bonus earnings section of dashboard.js that occurs when only one boost is active