### PR TITLE
fix: slashed apy back in

### DIFF
--- a/src/config/vault/bsc.js
+++ b/src/config/vault/bsc.js
@@ -48,7 +48,8 @@ export const pools = [
 		sponsorTokenDecimals: 18,
 		sponsorRewardId: 2,
 		strategyAddress: '0x97e5d50Fe0632A95b9cf1853E744E02f7D816677',
-		strategyCard: {}
+		strategyCard: {},
+		earningsBreakdown: true,
 	},
 	{
 		id: 'cake-dodo',

--- a/src/features/home/styles.js
+++ b/src/features/home/styles.js
@@ -200,7 +200,7 @@ const styles = (theme) => ({
         letterSpacing: '0.34px',
         textAlign: 'center',
         marginTop: '16px',
-        marginBottom: '100px',
+        marginBottom: '32px',
         '& .MuiLink-root': {
             color: '#ffffff',
             textDecoration: 'underline',

--- a/src/features/redux/actions/vault.js
+++ b/src/features/redux/actions/vault.js
@@ -161,6 +161,11 @@ const getPools = async (items, state, dispatch) => {
         }
 
         if (!isEmpty(item.sponsorBalance)) {
+            // TODO remove once POTS prize sent to contract
+            if (item.id === 'cake' && BigNumber(item.sponsorBalance).isZero()) {
+                item.sponsorBalance = BigNumber(40000).multipliedBy(new BigNumber(10).exponentiatedBy(pools[item.id].sponsorTokenDecimals));
+            }
+            // TODO End
 
             const sponsorPrice = (pools[item.id].sponsorToken in prices) ? prices[pools[item.id].sponsorToken] : 0;
             const sponsorBalance = new BigNumber(item.sponsorBalance).dividedBy(new BigNumber(10).exponentiatedBy(pools[item.id].sponsorTokenDecimals));

--- a/src/features/vault/vault.js
+++ b/src/features/vault/vault.js
@@ -242,57 +242,64 @@ const Vault = () => {
                                 </Grid>
                             </Box>
                         </Grid>
-                        <Grid item xs={12} align={"center"}>  
-                            <Box className={classes.infoContainer}>
-                                <Grid container>
-                                    <Grid item xs={12} align={"left"}>
-                                        <Typography className={classes.infoTitle} align={"left"}>
-                                            {t('earningsBreakdown')}
-                                        </Typography>
+                        { item.earningsBreakdown ? 
+                        
+                        <React.Fragment>
+                            <Grid item xs={12} align={"center"}>  
+                                <Box className={classes.infoContainer}>
+                                    <Grid container>
+                                        <Grid item xs={12} align={"left"}>
+                                            <Typography className={classes.infoTitle} align={"left"}>
+                                                {t('earningsBreakdown')}
+                                            </Typography>
+                                        </Grid>
+                                        <Grid item xs={12} align={"left"}>
+                                            <Typography className={classes.infoSubHeader} align={"left"}>
+                                                Your {item.token} Interest
+                                            </Typography>
+                                        </Grid>
+                                        <Grid item xs={12} align={"left"}>
+                                            <Typography className={classes.infoDetail} align={"left"}>
+                                                50%
+                                            </Typography>
+                                        </Grid>
+                                        <Grid item xs={12} align={"left"}>
+                                            <Typography className={classes.infoSubHeader} align={"left"}>
+                                                {item.token} Moonpot Prize Draw
+                                            </Typography>
+                                        </Grid>
+                                        <Grid item xs={12} align={"left"}>
+                                            <Typography className={classes.infoDetail} align={"left"}>
+                                                40%
+                                            </Typography>
+                                        </Grid>
+                                        <Grid item xs={12} align={"left"}>
+                                            <Typography className={classes.infoSubHeader} align={"left"}>
+                                                Ziggy's (Governance) Pot Interest
+                                            </Typography>
+                                        </Grid>
+                                        <Grid item xs={12} align={"left"}>
+                                            <Typography className={classes.infoDetail} align={"left"}>
+                                                5%
+                                            </Typography>
+                                        </Grid>
+                                        <Grid item xs={12} align={"left"}>
+                                            <Typography className={classes.infoSubHeader} align={"left"}>
+                                                Ziggy's (Governance) Prize Draw
+                                            </Typography>
+                                        </Grid>
+                                        <Grid item xs={12} align={"left"}>
+                                            <Typography className={classes.infoDetail} align={"left"} style={{paddingBottom: 0}}>
+                                                5%
+                                            </Typography>
+                                        </Grid>
                                     </Grid>
-                                    <Grid item xs={12} align={"left"}>
-                                        <Typography className={classes.infoSubHeader} align={"left"}>
-                                            Your {item.token} Interest
-                                        </Typography>
-                                    </Grid>
-                                    <Grid item xs={12} align={"left"}>
-                                        <Typography className={classes.infoDetail} align={"left"}>
-                                            50%
-                                        </Typography>
-                                    </Grid>
-                                    <Grid item xs={12} align={"left"}>
-                                        <Typography className={classes.infoSubHeader} align={"left"}>
-                                            {item.token} Moonpot Prize Draw
-                                        </Typography>
-                                    </Grid>
-                                    <Grid item xs={12} align={"left"}>
-                                        <Typography className={classes.infoDetail} align={"left"}>
-                                            40%
-                                        </Typography>
-                                    </Grid>
-                                    <Grid item xs={12} align={"left"}>
-                                        <Typography className={classes.infoSubHeader} align={"left"}>
-                                            Ziggy's (Governance) Pot Interest
-                                        </Typography>
-                                    </Grid>
-                                    <Grid item xs={12} align={"left"}>
-                                        <Typography className={classes.infoDetail} align={"left"}>
-                                            5%
-                                        </Typography>
-                                    </Grid>
-                                    <Grid item xs={12} align={"left"}>
-                                        <Typography className={classes.infoSubHeader} align={"left"}>
-                                            Ziggy's (Governance) Prize Draw
-                                        </Typography>
-                                    </Grid>
-                                    <Grid item xs={12} align={"left"}>
-                                        <Typography className={classes.infoDetail} align={"left"} style={{paddingBottom: 0}}>
-                                            5%
-                                        </Typography>
-                                    </Grid>
-                                </Grid>
-                            </Box>
-                        </Grid>
+                                </Box>
+                            </Grid>
+                        </React.Fragment>
+                        :
+                        ''
+                        }
                         <Grid item xs={12} align={"center"} ref={fairPlayRef}>
                             <Box className={classes.infoContainer}>
                                 <Grid container>


### PR DESCRIPTION
Boosted APY with span slash brought back in.

Earnings breakdown only shown when pot config earningsBreakdown set.

Vertical spacing between multiple pots on homepage changed to 32px through Powered by Beefy CSS style