### PR TITLE
fix: redux code for bonusApy tries boost then looks for sponsor reward

### DIFF
--- a/src/features/dashboard/dashboard.js
+++ b/src/features/dashboard/dashboard.js
@@ -331,7 +331,7 @@ const Dashboard = () => {
                                                                     <Typography className={classes.myDetailsText} align={'left'}>{t('myInterestRate')}</Typography>
                                                                 </Grid>
                                                                 <Grid item xs={6}>
-                                                                    <Typography className={classes.myDetailsValue} align={"right"}>{item.bonusApy > 0 ? new BigNumber(item.apy).plus(item.bonusApy).toFixed(2) : item.apy}% APY</Typography>
+                                                                    <Typography className={classes.myDetailsValue} align={"right"}><span>{item.apy}%</span> {item.bonusApy > 0 ? new BigNumber(item.apy).plus(item.bonusApy).toFixed(2) : item.apy}% APY</Typography>
                                                                 </Grid>
                                                                 <Grid item xs={6}>
                                                                     <Typography className={classes.myDetailsText} align={'left'}>{t('myOdds')}</Typography>

--- a/src/features/redux/actions/vault.js
+++ b/src/features/redux/actions/vault.js
@@ -132,18 +132,19 @@ const getPools = async (items, state, dispatch) => {
                     const rewardRate = new BigNumber(item.boostRewardInfo['3']);
                     const yearlyRewards = rewardRate.times(3600).times(24).times(365);
                     boostRewardsInUsd = yearlyRewards.times(boostPrice).dividedBy(new BigNumber(10).exponentiatedBy(pools[item.id].boostTokenDecimals))
+                    pools[item.id].bonusApy = Number(yearlyRewardsInUsd.plus(boostRewardsInUsd).multipliedBy(100).dividedBy(totalStakedUsd));
+                
+                } else if (!isEmpty(pools[item.id].sponsorToken)) {
+
+                    const sponsorPrice = (pools[item.id].sponsorToken in prices) ? prices[pools[item.id].sponsorToken] : 0;
+                    const rewardRate = new BigNumber(item.rewardRate);
+                    const TotalValueLocked = new BigNumber(item.totalValueLocked);
+                    const totalStakedUsd = TotalValueLocked.times(awardPrice).dividedBy(new BigNumber(10).exponentiatedBy(pools[item.id].sponsorTokenDecimals));
+                    const yearlyRewards = rewardRate.times(3600).times(24).times(365);
+                    const yearlyRewardsInUsd = yearlyRewards.times(sponsorPrice).dividedBy(new BigNumber(10).exponentiatedBy(pools[item.id].sponsorTokenDecimals))
+
+                    pools[item.id].bonusApy = Number(yearlyRewardsInUsd.multipliedBy(100).dividedBy(totalStakedUsd));
                 }
-
-                pools[item.id].bonusApy = Number(yearlyRewardsInUsd.plus(boostRewardsInUsd).multipliedBy(100).dividedBy(totalStakedUsd));
-            } else if (!isEmpty(pools[item.id].sponsorToken)) {
-                const sponsorPrice = (pools[item.id].sponsorToken in prices) ? prices[pools[item.id].sponsorToken] : 0;
-                const rewardRate = new BigNumber(item.rewardRate);
-                const TotalValueLocked = new BigNumber(item.totalValueLocked);
-                const totalStakedUsd = TotalValueLocked.times(awardPrice).dividedBy(new BigNumber(10).exponentiatedBy(pools[item.id].sponsorTokenDecimals));
-                const yearlyRewards = rewardRate.times(3600).times(24).times(365);
-                const yearlyRewardsInUsd = yearlyRewards.times(sponsorPrice).dividedBy(new BigNumber(10).exponentiatedBy(pools[item.id].sponsorTokenDecimals))
-
-                pools[item.id].bonusApy = Number(yearlyRewardsInUsd.multipliedBy(100).dividedBy(totalStakedUsd));
             }
 
             if (pools[item.id].status === 'active') {


### PR DESCRIPTION
Split apys are brought back in

bonusApy - Redux code looks for boost reward first then looks for sponsor reward. This needs revisiting for the future, with thought around multiple sponsor and boost tokens possibly impacting the APY. Multiple pages show bonuses and we should also look at generating the content from the config and where we show all the available bonuses, what is an active pot and what is eol and again, where we show these values.