### PR TITLE
Check POTS allowance before compound

### DIFF
--- a/src/features/dashboard/dashboard.js
+++ b/src/features/dashboard/dashboard.js
@@ -188,6 +188,20 @@ const Dashboard = () => {
   const handleCompoundBonus = item => {
     if (wallet.address) {
       const steps = [];
+
+      const tokenApproved = balance.tokens[item.token]?.allowance[item.contractAddress];
+      if (!tokenApproved) {
+        steps.push({
+          step: 'approve',
+          message: 'Approval transaction happens once per pot.',
+          action: () =>
+            dispatch(
+              reduxActions.wallet.approval(item.network, item.tokenAddress, item.contractAddress)
+            ),
+          pending: false,
+        });
+      }
+
       steps.push({
         step: 'compound',
         message: 'Confirm compound transaction on wallet to complete.',


### PR DESCRIPTION
Check POTS allowance before compound, and enqueue approval TX first if its zero.

(Someone in Discord had revoked approval; stopping the compound TX from working)