### PR TITLE
Tidy cards/accordion

### DIFF
--- a/src/components/Cards/Cards.js
+++ b/src/components/Cards/Cards.js
@@ -17,7 +17,7 @@ export function Cards({ className, children, ...rest }) {
 
   return (
     <div className={clsx(classes.cards, className)} {...rest}>
-      {children}
+      <div className={classes.cardsInner}>{children}</div>
     </div>
   );
 }

--- a/src/components/Cards/styles.js
+++ b/src/components/Cards/styles.js
@@ -1,7 +1,21 @@
 const styles = () => ({
   cards: {
-    '& > $card + $card': {
-      marginTop: '24px',
+    width: `${500 * 2 + 24 * 2}px`,
+    maxWidth: '100%',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+  },
+  cardsInner: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    marginLeft: '-12px',
+    marginRight: '-12px',
+    marginBottom: '-24px',
+    '& > *, & > $card': {
+      marginBottom: '24px',
+      marginLeft: '12px',
+      marginRight: '12px',
     },
   },
   card: {
@@ -9,7 +23,8 @@ const styles = () => ({
     maxWidth: '100%',
     borderRadius: '16px',
     boxSizing: 'border-box',
-    margin: '0 auto',
+    marginLeft: 'auto',
+    marginRight: 'auto',
     padding: '24px',
     borderWidth: '2px',
     borderStyle: 'solid',
@@ -29,6 +44,10 @@ const styles = () => ({
   accordionItem: {
     borderTop: 'solid 2px red',
     paddingTop: '16px',
+    paddingBottom: '16px',
+    '&:last-child': {
+      paddingBottom: '0',
+    },
   },
   accordionItemTitle: {
     fontStyle: 'normal',
@@ -58,13 +77,13 @@ const styles = () => ({
     },
   },
   accordionItemInner: {
-    paddingTop: '12px',
     fontStyle: 'normal',
     fontWeight: 'normal',
     fontSize: '12px',
     lineHeight: '20px',
     letterSpacing: '0.2px',
     color: 'red',
+    paddingTop: '16px',
   },
   variantPurpleDark: {
     color: '#DFDFEC',

--- a/src/features/dashboard/components/Pot/PotBonus.js
+++ b/src/features/dashboard/components/Pot/PotBonus.js
@@ -126,7 +126,7 @@ const PotBonus = function ({ item, prices, wallet, balance }) {
   }, [steps, wallet.action]);
 
   return (
-    <Grid container className={classes.bonusEarningsInner}>
+    <Grid container>
       <Steps item={stepsItem} steps={steps} handleClose={handleClose} />
       <Grid item xs={6}>
         <Typography className={classes.myDetailsText} align={'left'} style={{ marginBottom: 0 }}>

--- a/src/features/dashboard/components/Pot/PotComponents.js
+++ b/src/features/dashboard/components/Pot/PotComponents.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Box, Grid, makeStyles, Link, Typography } from '@material-ui/core';
+import { Grid, Link, makeStyles, Typography } from '@material-ui/core';
 import styles from '../../styles';
 import { investmentOdds } from '../../../../helpers/utils';
 import { Trans, useTranslation } from 'react-i18next';

--- a/src/features/dashboard/dashboard.js
+++ b/src/features/dashboard/dashboard.js
@@ -9,11 +9,7 @@ import { isEmpty } from '../../helpers/utils';
 import { byDecimals } from '../../helpers/format';
 import NoPotsCard from './components/NoPotsCard/NoPotsCard';
 import Pot from './components/Pot/Pot';
-import { Cards } from '../../components/Cards/Cards';
-import styles from './styles';
-import { makeStyles } from '@material-ui/core';
-
-const useStyles = makeStyles(styles);
+import { Cards } from '../../components/Cards';
 
 const VALID_STATUSES = ['active', 'eol'];
 const defaultFilter = {
@@ -29,7 +25,7 @@ const getDefaultFilter = (params = {}) => {
 
 const Dashboard = () => {
   const { t } = useTranslation();
-  const classes = useStyles();
+
   const { vault, wallet, balance, prices, earned } = useSelector(state => ({
     vault: state.vaultReducer,
     wallet: state.walletReducer,
@@ -137,17 +133,15 @@ const Dashboard = () => {
         </Grid>
         <Grid container style={{ marginTop: '56px' }}>
           {/*Pots*/}
-          <div className={classes.potList}>
-            <div className={classes.potListInner}>
-              {filtered.length === 0 ? (
-                <NoPotsCard />
-              ) : (
-                filtered.map(item => (
-                  <Pot item={item} wallet={wallet} prices={prices} balance={balance} />
-                ))
-              )}
-            </div>
-          </div>
+          <Cards>
+            {filtered.length === 0 ? (
+              <NoPotsCard />
+            ) : (
+              filtered.map(item => (
+                <Pot item={item} wallet={wallet} prices={prices} balance={balance} />
+              ))
+            )}
+          </Cards>
         </Grid>
       </Container>
     </React.Fragment>

--- a/src/features/dashboard/styles.js
+++ b/src/features/dashboard/styles.js
@@ -379,9 +379,6 @@ const styles = theme => ({
       borderColor: '#CCCCCC',
     },
   },
-  bonusEarningsInner: {
-    paddingBottom: '16px',
-  },
   explainerText: {
     fontFamily: 'Ubuntu',
     fontStyle: 'normal',
@@ -417,7 +414,6 @@ const styles = theme => ({
     fontWeight: '700',
   },
   interestValueBaseApy: {
-    color: '#A0BBD5',
     textDecoration: 'line-through',
     fontSize: '12px',
     lineHeight: '20px',
@@ -427,25 +423,6 @@ const styles = theme => ({
     fontSize: '12px',
     lineHeight: '20px',
     fontWeight: '700',
-  },
-  potList: {
-    width: `${500 * 2 + 24 * 2}px`,
-    maxWidth: '100%',
-    marginLeft: 'auto',
-    marginRight: 'auto',
-  },
-  potListInner: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
-    marginLeft: '-12px',
-    marginRight: '-12px',
-    marginBottom: '-24px',
-    '& > *': {
-      marginBottom: '24px',
-      marginLeft: '12px',
-      marginRight: '12px',
-    },
   },
 });
 

--- a/src/features/home/components/Pot/package.json
+++ b/src/features/home/components/Pot/package.json
@@ -1,3 +1,3 @@
 {
-  "main": "pot.js"
+  "main": "Pot.js"
 }

--- a/src/features/home/home.js
+++ b/src/features/home/home.js
@@ -9,9 +9,10 @@ import { MigrationNotices } from './components/MigrationNotices/MigrationNotices
 import ZiggyMaintenance from '../../images/ziggy/maintenance.svg';
 import SocialMediaBlock from './components/SocialMediaBlock/SocialMediaBlock';
 import { useFilterConfig, useFilteredPots } from './hooks/filter';
-import { Pot } from './components/Pot/Pot';
-import { TVL } from './components/TVL/TVL';
+import { Pot } from './components/Pot';
+import { TVL } from './components/TVL';
 import { PoweredByBeefy } from '../../components/PoweredByBeefy';
+import { Cards } from '../../components/Cards';
 
 const useStyles = makeStyles(styles);
 
@@ -43,13 +44,11 @@ const Home = () => {
       <TVL className={classes.totalTVL} />
       <Filter config={filterConfig} setConfig={setFilterConfig} className={classes.potsFilter} />
       <MigrationNotices potType={filterConfig.vault} className={classes.potsMigrationNotice} />
-      <div className={classes.potList}>
-        <div className={classes.potListInner}>
-          {filtered.map(pot => (
-            <Pot key={pot.id} id={pot.id} />
-          ))}
-        </div>
-      </div>
+      <Cards>
+        {filtered.map(pot => (
+          <Pot key={pot.id} id={pot.id} />
+        ))}
+      </Cards>
       {filterConfig.vault === 'community' && filtered.length === 0 ? (
         <Grid item xs={12}>
           <Grid container className={classes.communityJoin}>

--- a/src/features/home/styles.js
+++ b/src/features/home/styles.js
@@ -26,25 +26,6 @@ const styles = theme => ({
   potsMigrationNotice: {
     marginBottom: '24px',
   },
-  potList: {
-    width: `${500 * 2 + 24 * 2}px`,
-    maxWidth: '100%',
-    marginLeft: 'auto',
-    marginRight: 'auto',
-  },
-  potListInner: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
-    marginLeft: '-12px',
-    marginRight: '-12px',
-    marginBottom: '-24px',
-    '& > *': {
-      marginBottom: '24px',
-      marginLeft: '12px',
-      marginRight: '12px',
-    },
-  },
   communityJoin: {
     margin: '0 auto',
     width: '500px',


### PR DESCRIPTION
This should fix the inconsistent styles cause with the recent merge of dashboard + winners.

- `<Cards>` component will now display 2 `<Card>`s side by side if there is room.
- Use the `<Cards>` component for Home/Dashboard/Winners
- Tidy accordion styles: Fix padding/spacing
- Crossed out APY colour on dashboard