### PR TITLE
Fixes: Odds etc.

### DIFF
--- a/src/components/Pot/Pot.js
+++ b/src/components/Pot/Pot.js
@@ -112,9 +112,10 @@ const TVL = memo(function ({ totalStakedUsd }) {
   return '$0';
 });
 
-const Deposit = memo(function ({ depositToken, rewardToken, decimals }) {
+const Deposit = memo(function ({ depositToken, contractAddress, decimals }) {
   const address = useSelector(state => state.walletReducer.address);
-  const balance256 = useSelector(state => state.balanceReducer.tokens[rewardToken]?.balance);
+  const balance256 = useSelector(state => state.balanceReducer.tokens[contractAddress]?.balance);
+
   const balance = useMemo(() => {
     if (address && balance256) {
       return formatDecimals(byDecimals(balance256, decimals), 2);
@@ -162,7 +163,7 @@ export function Pot({ id, variant, bottom }) {
           <DrawStat i18nKey="pot.statDeposit">
             <Deposit
               depositToken={pot.token}
-              rewardToken={pot.rewardToken}
+              contractAddress={pot.contractAddress}
               decimals={pot.tokenDecimals}
             />
           </DrawStat>

--- a/src/config/tokens/bsc.json
+++ b/src/config/tokens/bsc.json
@@ -43,5 +43,18 @@
     "symbol": "DODO",
     "oracleId": "DODO",
     "decimals": 18
+  },
+  {
+    "address": "0x603c7f932ED1fc6575303D8Fb018fDCBb0f39a95",
+    "symbol": "BANANA",
+    "oracleId": "BANANA",
+    "decimals": 18
+  },
+  {
+    "address": "0x81b554A2C3aD52630Cf1Ca56cad562EC4A551873",
+    "symbol": "moonTicketBanana",
+    "displaySymbol": "BANANA",
+    "oracleId": "BANANA",
+    "decimals": 18
   }
 ]

--- a/src/features/dashboard/components/Pot/PotComponents.js
+++ b/src/features/dashboard/components/Pot/PotComponents.js
@@ -1,12 +1,14 @@
 import * as React from 'react';
+import { memo, useMemo } from 'react';
 import { Grid, makeStyles, Typography } from '@material-ui/core';
 import styles from '../../styles';
 import { investmentOdds } from '../../../../helpers/utils';
 import { useTranslation } from 'react-i18next';
-import { formatDecimals } from '../../../../helpers/format';
+import { byDecimals, formatDecimals } from '../../../../helpers/format';
 import Countdown from '../../../../components/Countdown';
 import { InterestTooltip, WinTotal } from '../../../../components/Pot';
 import { Translate } from '../../../../components/Translate';
+import { useTokenBalance } from '../../../../helpers/hooks';
 
 const useStyles = makeStyles(styles);
 
@@ -75,6 +77,16 @@ const Interest = function ({ baseApy, bonusApy, bonusApr }) {
   );
 };
 
+const DepositedOdds = memo(function ({ ticketTotalSupply, winners, ticketToken, tokenDecimals }) {
+  const depositedTickets = useTokenBalance(ticketToken, tokenDecimals);
+
+  const odds = useMemo(() => {
+    return investmentOdds(byDecimals(ticketTotalSupply, tokenDecimals), winners, depositedTickets);
+  }, [ticketTotalSupply, depositedTickets, winners, tokenDecimals]);
+
+  return <Translate i18nKey="pot.odds" values={{ odds }} />;
+});
+
 export const PotInfoBlock = function ({ item, prices }) {
   const classes = useStyles();
   const { t } = useTranslation();
@@ -112,13 +124,12 @@ export const PotInfoBlock = function ({ item, prices }) {
         </Grid>
         <Grid item xs={6}>
           <Typography className={classes.myDetailsValue} align={'right'}>
-            {t('pot.odds', {
-              odds: investmentOdds(
-                item.totalStakedUsd,
-                item.userBalance.times(prices.prices[item.oracleId]),
-                item.numberOfWinners
-              ),
-            })}
+            <DepositedOdds
+              ticketTotalSupply={item.totalTickets}
+              winners={item.numberOfWinners}
+              ticketToken={item.rewardToken}
+              tokenDecimals={item.tokenDecimals}
+            />
           </Typography>
         </Grid>
       </Grid>

--- a/src/features/dashboard/components/Pot/PotMigrate.js
+++ b/src/features/dashboard/components/Pot/PotMigrate.js
@@ -57,14 +57,7 @@ export const PotMigrate = function ({ item, wallet, balance }) {
         step: 'withdraw',
         message: 'Confirm withdraw transaction on wallet to complete.',
         action: () =>
-          dispatch(
-            reduxActions.wallet.withdraw(
-              item.network,
-              item.contractAddress,
-              balance.tokens[item.rewardToken].balance,
-              true
-            )
-          ),
+          dispatch(reduxActions.wallet.withdraw(item.network, item.contractAddress, 0, true)),
         pending: false,
       });
 
@@ -93,7 +86,7 @@ export const PotMigrate = function ({ item, wallet, balance }) {
             reduxActions.wallet.deposit(
               item.network,
               item.migrationContractAddress,
-              balance.tokens[item.rewardToken].balance,
+              balance.tokens[item.contractAddress].balance,
               false
             )
           ),

--- a/src/features/dashboard/dashboard.js
+++ b/src/features/dashboard/dashboard.js
@@ -63,7 +63,7 @@ const Dashboard = () => {
         return false;
       }
 
-      if (Number(balance.tokens[item.rewardToken].balance) === 0) {
+      if (Number(balance.tokens[item.contractAddress].balance) === 0) {
         return false;
       }
 
@@ -72,9 +72,9 @@ const Dashboard = () => {
 
     for (const [, item] of Object.entries(vault.pools)) {
       if (check(item)) {
-        if (wallet.address && !isEmpty(balance.tokens[item.rewardToken])) {
+        if (wallet.address && !isEmpty(balance.tokens[item.contractAddress])) {
           item.userBalance = byDecimals(
-            new BigNumber(balance.tokens[item.rewardToken].balance),
+            new BigNumber(balance.tokens[item.contractAddress].balance),
             item.tokenDecimals
           );
         }

--- a/src/features/home/components/MigrationNotices/MigrationNotices.js
+++ b/src/features/home/components/MigrationNotices/MigrationNotices.js
@@ -1,6 +1,5 @@
-import React, { useEffect, useMemo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import reduxActions from '../../../redux/actions';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { byDecimals } from '../../../../helpers/format';
 import BigNumber from 'bignumber.js';
 import { Box, makeStyles } from '@material-ui/core';
@@ -15,7 +14,7 @@ function MigrationNotice({ pot }) {
   const classes = useStyles();
   const { t } = useTranslation();
   const balanceString = useSelector(
-    state => state.balanceReducer.tokens[pot.rewardToken]?.balance || '0'
+    state => state.balanceReducer.tokens[pot.contractAddress]?.balance || '0'
   );
   const balanceTokenDecimals = pot.tokenDecimals;
   const balanceBigNumber = useMemo(
@@ -72,7 +71,6 @@ export function MigrationNotices({ potType }) {
   const currentNetwork = useSelector(state => state.walletReducer.network);
   const currentAddress = useSelector(state => state.walletReducer.address);
   const allPots = useSelector(state => state.vaultReducer.pools);
-  const dispatch = useDispatch();
 
   const potsNeedingMigration = useMemo(() => {
     return Object.values(allPots).filter(
@@ -84,12 +82,6 @@ export function MigrationNotices({ potType }) {
     );
   }, [potType, allPots, currentNetwork]);
   const hasPotsNeedingMigration = potsNeedingMigration.length > 0;
-
-  useEffect(() => {
-    if (currentAddress && hasPotsNeedingMigration) {
-      dispatch(reduxActions.balance.fetchBalances());
-    }
-  }, [dispatch, currentAddress, hasPotsNeedingMigration]);
 
   if (currentAddress && hasPotsNeedingMigration) {
     return (

--- a/src/features/home/home.js
+++ b/src/features/home/home.js
@@ -20,6 +20,7 @@ const Home = ({ selected }) => {
   const dispatch = useDispatch();
   const pricesLastUpdated = useSelector(state => state.pricesReducer.lastUpdated);
   const totalPrizesAvailable = useSelector(state => state.vaultReducer.totalPrizesAvailable);
+  const address = useSelector(state => state.walletReducer.address);
   const pots = useSelector(state => state.vaultReducer.pools, shallowEqual);
   const classes = useStyles();
   const [filterConfig, setFilterConfig] = useFilterConfig();
@@ -35,6 +36,12 @@ const Home = ({ selected }) => {
       dispatch(reduxActions.vault.fetchPools());
     }
   }, [dispatch, pricesLastUpdated]);
+
+  useEffect(() => {
+    if (address) {
+      dispatch(reduxActions.balance.fetchBalances());
+    }
+  }, [dispatch, address]);
 
   return (
     <Container maxWidth="xl">

--- a/src/features/redux/actions/balance.js
+++ b/src/features/redux/actions/balance.js
@@ -30,8 +30,8 @@ const getBalances = async (pools, state, dispatch) => {
     const gateContract = new web3[pool.network].eth.Contract(gateManagerAbi, pool.contractAddress);
     calls[pool.network].push({
       amount: gateContract.methods.userTotalBalance(address),
-      token: pool.rewardToken,
-      address: pool.rewardAddress,
+      token: pool.contractAddress,
+      address: pool.contractAddress,
     });
 
     calls[pool.network].push({
@@ -42,6 +42,8 @@ const getBalances = async (pools, state, dispatch) => {
 
     const ticketContract = new web3[pool.network].eth.Contract(erc20Abi, pool.rewardAddress);
     calls[pool.network].push({
+      amount: ticketContract.methods.balanceOf(address),
+      address: pool.rewardAddress,
       allowance: ticketContract.methods.allowance(address, pool.contractAddress),
       token: pool.rewardToken,
       spender: pool.contractAddress,
@@ -65,7 +67,8 @@ const getBalances = async (pools, state, dispatch) => {
         balance: r.amount,
         address: r.address,
       };
-    } else if (r.allowance !== undefined) {
+    }
+    if (r.allowance !== undefined) {
       tokens[r.token].allowance = {
         ...tokens[r.token].allowance,
         [r.spender]: parseInt(r.allowance),

--- a/src/features/redux/reducers/balance.js
+++ b/src/features/redux/reducers/balance.js
@@ -18,6 +18,11 @@ const initialTokens = () => {
         allowance: { [networkPools[key].contractAddress]: 0 },
         address: networkPools[key].rewardAddress,
       };
+
+      tokens[networkPools[key].contractAddress] = {
+        balance: 0,
+        address: networkPools[key].contractAddress,
+      };
     }
   }
 
@@ -39,6 +44,7 @@ const balanceReducer = (state = initialState, action) => {
         isBalancesLoading: state.isBalancesFirstTime,
       };
     case BALANCE_FETCH_BALANCES_DONE:
+      console.log(action.payload.tokens);
       return {
         ...state,
         tokens: action.payload.tokens,

--- a/src/features/redux/reducers/vault.js
+++ b/src/features/redux/reducers/vault.js
@@ -20,6 +20,7 @@ const initialPools = () => {
       pool['totalSponsorBalanceUsd'] = new BigNumber(0);
       pool['totalStakedUsd'] = new BigNumber(0);
       pool['numberOfWinners'] = new BigNumber(5);
+      pool['totalTickets'] = new BigNumber(0);
       pool['defaultOrder'] = defaultOrder++;
       pool.sponsors.forEach(sponsor => {
         sponsor.sponsorBalance = new BigNumber(0);

--- a/src/helpers/hooks.js
+++ b/src/helpers/hooks.js
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import BigNumber from 'bignumber.js';
 import { useSelector } from 'react-redux';
 import { byDecimals } from './format';
+import { tokensByNetworkAddress } from '../config/tokens';
 
 export function usePrevious(value) {
   const ref = useRef();
@@ -79,6 +80,13 @@ export function useTokenEarned(id, token, tokenDecimals) {
 
     return byDecimals(bn, tokenDecimals);
   }, [earned, tokenDecimals]);
+}
+
+export function useTokenAddressPrice(address, network = 'bsc') {
+  const tokenData = tokensByNetworkAddress[network]?.[address.toLowerCase()];
+  return useSelector(state =>
+    tokenData ? state.pricesReducer.prices[tokenData.oracleId] || 0 : 0
+  );
 }
 
 export function usePot(id) {

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -26,11 +26,25 @@ export const getStablesForNetwork = () => {
   return config.stableCoins;
 };
 
-export const investmentOdds = (currentTvl, investment, winners) => {
-  const oddsOfWinningOnce = investment.dividedBy(currentTvl.plus(investment));
-  const oddsOfLosingOnce = BigNumber(1).minus(oddsOfWinningOnce);
-  const oddsOfWinningAtLeastOnce = BigNumber(1).minus(oddsOfLosingOnce.exponentiatedBy(winners));
-  return Math.ceil(1 / Number(oddsOfWinningAtLeastOnce));
+export const toBigNumber = maybeBigNumber => {
+  return BigNumber.isBigNumber(maybeBigNumber) ? maybeBigNumber : new BigNumber(maybeBigNumber);
+};
+
+export const investmentOdds = (
+  ticketTotalSupply,
+  numberOfWinners,
+  investedTickets = 0,
+  newInvestmentTickets = 0
+) => {
+  const finalTotalSupply = toBigNumber(ticketTotalSupply).plus(newInvestmentTickets);
+  const finalTicketsInvested = toBigNumber(investedTickets).plus(newInvestmentTickets);
+  const one = toBigNumber(1);
+
+  const oddsOfWinningOnce = finalTicketsInvested.dividedBy(finalTotalSupply);
+  const oddsOfLosingOnce = one.minus(oddsOfWinningOnce);
+  const oddsOfWinningAtLeastOnce = one.minus(oddsOfLosingOnce.exponentiatedBy(numberOfWinners));
+
+  return one.dividedBy(oddsOfWinningAtLeastOnce).integerValue(BigNumber.ROUND_CEIL).toNumber();
 };
 
 export function compound(r, n = 365, t = 1, c = 1) {


### PR DESCRIPTION
Closes #187 

### Summary

1. Fix: Odds based on tickets/totalSupply not userTotalBalance/TVL
2. Fix: Dashboard (already deposited) odds (was adding deposit to TVL, making odds longer than they actually were)
3. Fix: Community pots now show deposit when you load community tab first (prev had to load main pots)
4. Fix: Add banana/moonTicketBanana to tokens/bsc.json (needed for winners and new deposit odds)

### Dev Notes

We needed the user's balance of tickets to properly calculate the odds, however `gateContract.userTotalBalance` was being stored there (under `balanceReducer.tokens[pot.rewardToken].balance`)

**To accomodate this:**
- `balanceReducer.tokens[pot.rewardToken].balance` now stores the balance of tickets 
- `userTotalBalance` is now stored under `balanceReducer.tokens[pot.contractAddress].balance` (address used as key since there is no token)

**TLDR** Use `tokens[pot.contractAddress].balance` where you previously used `tokens[pot.rewardToken].balance` to get the user's total balance.

(There will almost certainly be merge conflicts with #210)

### User Communication Notes

Most users should see their odds get better with this update.
- If the user has just deposited their odds should be practically the same (slightly different due to 2. above).
- The longer the user has been staked, the bigger the difference will be in their odds.
- Odds on Ziggy's pot should not be effected by this change (no underlying interest earned)
