### PR TITLE
Remove bonus/super boost when they are at 0

### DIFF
--- a/src/features/home/MyPots/components/Pot/PotBonus.js
+++ b/src/features/home/MyPots/components/Pot/PotBonus.js
@@ -14,11 +14,11 @@ const useStyles = makeStyles(styles);
 const getItemBonusTokens = item => {
   const tokens = [];
 
-  if (item.bonusToken) {
+  if (item.bonusToken && item.earned > 0) {
     tokens.push(item.bonusToken);
   }
 
-  if (item.boostToken) {
+  if (item.boostToken && item.boosted > 0) {
     tokens.push(item.boostToken);
   }
 


### PR DESCRIPTION
Closes #233 
-If a user has 0 of either a bonus or boost token the data point will not be shown.
-The compound button will also be hidden if the compoundable token is at 0