### PR TITLE
fix: align xBLZD moonTicket naming to contract

### DIFF
--- a/src/config/tokens/bsc.json
+++ b/src/config/tokens/bsc.json
@@ -222,7 +222,7 @@
     "decimals": 18
   },
   {
-    "symbol": "moonTicketXBLZD",
+    "symbol": "moonTicketxBLZD",
     "address": "0xf6A91F8d3EC0b1922433c4E929Ea61C85633E918",
     "type": "ticket",
     "oracleId": "xBLZD",

--- a/src/config/vault/bsc.json
+++ b/src/config/vault/bsc.json
@@ -438,7 +438,7 @@
     "token": "xBLZD",
     "tokenAddress": "0x9a946c3Cb16c08334b69aE249690C236Ebd5583E",
     "tokenDecimals": 18,
-    "rewardToken": "moonTicketXBLZD",
+    "rewardToken": "moonTicketxBLZD",
     "rewardAddress": "0xf6A91F8d3EC0b1922433c4E929Ea61C85633E918",
     "contractAddress": "0x55A50FE2372c0B8A4491d4CeC517258D69940547",
     "prizePoolAddress": "0x861d4d8310006E6Ef115dF4A5D64A83e361aa29E",


### PR DESCRIPTION
Simple change to moonTicket xBLZD name references to align to contract