### PR TITLE
Winners ppfs

### DIFF
--- a/src/config/tokens/bsc.json
+++ b/src/config/tokens/bsc.json
@@ -286,9 +286,15 @@
     "symbol": "moonTicketPOTSv3",
     "address": "0xCd3941d4825c08991b98930ef18062f6df2959d4",
     "type": "ticket",
-    "oracleId": "POTS",
     "decimals": 18,
-    "underlyingToken": "POTS",
+    "underlyingToken": "mooPOTS",
     "stakedMultiplier": 1
+  },
+  {
+    "symbol": "mooPOTS",
+    "address": "0xC264c0D6e8A35AbB7a118e9592aD400f640471D9",
+    "type": "moo",
+    "decimals": 18,
+    "underlyingToken": "POTS"
   }
 ]

--- a/src/config/tokens/index.js
+++ b/src/config/tokens/index.js
@@ -2,7 +2,10 @@ import { config } from '../config';
 import { indexBy } from '../../helpers/utils';
 
 export const tokensByNetwork = Object.fromEntries(
-  Object.keys(config).map(network => [network, require(`./${network}.json`)])
+  Object.keys(config).map(network => [
+    network,
+    require(`./${network}.json`).map(token => ({ ...token, network })),
+  ])
 );
 
 export const tokensByNetworkAddress = Object.fromEntries(

--- a/src/features/redux/actions/prices.js
+++ b/src/features/redux/actions/prices.js
@@ -1,75 +1,177 @@
 import axios from 'axios';
-import { sleep } from '../../../helpers/utils';
+import { getApiCacheBuster, sleep } from '../../../helpers/utils';
+import { MultiCall } from 'eth-multicall';
+import { config } from '../../../config/config';
+import { tokensByNetworkAddress, tokensByNetworkSymbol } from '../../../config/tokens';
+import beefyVaultAbi from '../../../config/abi/beefyvault.json';
+import { byDecimals } from '../../../helpers/format';
 
-const fetchPrices = reducer => {
-  const cache = new Date();
-  cache.setSeconds(0, 0);
+function derivePrice(token, tokens, prices, ppfs) {
+  if (token.underlyingToken) {
+    const underlying = tokens[token.underlyingToken];
+    if (!underlying) {
+      throw new Error(
+        `Underlying token ${token.underlyingToken} not found in tokens list for ${token.symbol}/${token.address}`
+      );
+    }
 
+    if (token.type === 'moo') {
+      if (!(token.network in ppfs) || !(token.address in ppfs[token.network])) {
+        throw new Error(`PPFS not found for ${token.symbol}/${token.address}`);
+      }
+
+      return ppfs[token.network][token.address] * derivePrice(underlying, tokens, prices, ppfs);
+    }
+
+    return derivePrice(underlying, tokens, prices, ppfs);
+  }
+
+  if (!token.oracleId || !(token.oracleId in prices)) {
+    throw new Error(
+      `Oracle ${token.oracleId} not found in prices for ${token.symbol}/${token.address}`
+    );
+  }
+
+  return prices[token.oracleId];
+}
+
+async function derivePrices(existing, prices, ppfs) {
+  const output = {};
+
+  for (const [network, tokens] of Object.entries(tokensByNetworkSymbol)) {
+    output[network] = { ...existing[network] };
+    for (const token of Object.values(tokens)) {
+      output[network][token.address] = derivePrice(token, tokens, prices, ppfs);
+    }
+  }
+
+  return output;
+}
+
+async function updatePPFS(web3, existing) {
+  console.log('redux updatePPFS called.');
+
+  const multicall = {};
+  const calls = {};
+  const output = {};
+
+  for (const network in web3) {
+    multicall[network] = new MultiCall(web3[network], config[network].multicallAddress);
+    calls[network] = [];
+    output[network] = { ...existing[network] };
+
+    for (const token of Object.values(tokensByNetworkAddress[network])) {
+      if (token.type === 'moo') {
+        const tokenContract = new web3[network].eth.Contract(beefyVaultAbi, token.address);
+        calls[network].push({
+          ppfs: tokenContract.methods.getPricePerFullShare(),
+          address: token.address,
+          network: network,
+        });
+      }
+    }
+  }
+
+  const promises = [];
+  for (const network in multicall) {
+    if (calls[network].length) {
+      promises.push(multicall[network].all([calls[network]]));
+    }
+  }
+
+  if (promises.length) {
+    const allResults = await Promise.all(promises);
+    for (const [results] of allResults) {
+      for (const result of results) {
+        output[result.network][result.address] = byDecimals(result.ppfs, 18).toNumber();
+      }
+    }
+  }
+
+  return output;
+}
+
+async function updatePrices() {
+  console.log('redux fetchPrices called.');
+  const retry = async () => {
+    await sleep(1000);
+    return await updatePrices();
+  };
+
+  try {
+    const request = await axios.get('https://api.beefy.finance/prices?_=' + getApiCacheBuster(), {
+      timeout: 2000,
+    });
+    return request.status === 200 ? request.data : retry();
+  } catch (err) {
+    console.log('error fetchPrices()', err);
+    return retry();
+  }
+}
+
+async function updateLPPrices() {
+  console.log('redux fetchLPPrices called.');
+  const retry = async () => {
+    await sleep(1000);
+    return await updateLPPrices();
+  };
+
+  try {
+    const request = await axios.get('https://api.beefy.finance/lps?_=' + getApiCacheBuster(), {
+      timeout: 2000,
+    });
+    return request.status === 200 ? request.data : retry();
+  } catch (err) {
+    console.log('error fetchPrices()', err);
+    return retry();
+  }
+}
+
+async function updateApy() {
+  console.log('redux fetchApy called.');
+  const retry = async () => {
+    await sleep(1000);
+    return await updateApy();
+  };
+  try {
+    const request = await axios.get(
+      'https://api.beefy.finance/apy/breakdown?_=' + getApiCacheBuster(),
+      { timeout: 2000 }
+    );
+    return request.status === 200 ? request.data : retry();
+  } catch (err) {
+    console.log('error fetchApy()', err);
+    return retry();
+  }
+}
+
+const fetchPrices = () => {
   return async (dispatch, getState) => {
-    const updatePrices = async () => {
-      console.log('redux fetchPrices called.');
-      const retry = async () => {
-        await sleep(1000);
-        return await updatePrices();
-      };
-
-      try {
-        const request = await axios.get('https://api.beefy.finance/prices?_=' + cache.getTime(), {
-          timeout: 2000,
-        });
-        return request.status === 200 ? request.data : retry();
-      } catch (err) {
-        console.log('error fetchPrices()', err);
-        return retry();
-      }
-    };
-
-    const updateLPPrices = async () => {
-      console.log('redux fetchLPPrices called.');
-      const retry = async () => {
-        await sleep(1000);
-        return await updateLPPrices();
-      };
-
-      try {
-        const request = await axios.get('https://api.beefy.finance/lps?_=' + cache.getTime(), {
-          timeout: 2000,
-        });
-        return request.status === 200 ? request.data : retry();
-      } catch (err) {
-        console.log('error fetchPrices()', err);
-        return retry();
-      }
-    };
-
-    const updateApy = async () => {
-      console.log('redux fetchApy called.');
-      const retry = async () => {
-        await sleep(1000);
-        return await updateApy();
-      };
-      try {
-        const request = await axios.get(
-          'https://api.beefy.finance/apy/breakdown?_=' + cache.getTime(),
-          { timeout: 2000 }
-        );
-        return request.status === 200 ? request.data : retry();
-      } catch (err) {
-        console.log('error fetchApy()', err);
-        return retry();
-      }
-    };
-
     const fetch = async () => {
       const state = getState();
-      const prices = await updatePrices(state.pricesReducer);
-      const lpPrices = await updateLPPrices(state.pricesReducer);
-      const apy = await updateApy(state.pricesReducer);
+      const [prices, lpPrices, apy, ppfs] = await Promise.all([
+        updatePrices(),
+        updateLPPrices(),
+        updateApy(),
+        updatePPFS(state.walletReducer.rpc, state.pricesReducer.ppfs),
+      ]);
+      const allPrices = {
+        ...state.pricesReducer.prices,
+        ...prices,
+        ...lpPrices,
+      };
+      const derivedPrices = await derivePrices(
+        state.pricesReducer.byNetworkAddress,
+        allPrices,
+        ppfs
+      );
 
       dispatch({
         type: 'FETCH_PRICES',
         payload: {
-          prices: { ...state.pricesReducer.prices, ...prices, ...lpPrices },
+          prices: allPrices,
+          byNetworkAddress: derivedPrices,
+          ppfs: ppfs,
           apy: apy,
           lastUpdated: new Date().getTime(),
         },

--- a/src/features/redux/reducers/prices.js
+++ b/src/features/redux/reducers/prices.js
@@ -1,6 +1,10 @@
+import { config } from '../../../config/config';
+
 const initialState = {
   prices: [],
   apy: [],
+  ppfs: Object.fromEntries(Object.keys(config).map(network => [network, {}])),
+  byNetworkAddress: Object.fromEntries(Object.keys(config).map(network => [network, {}])),
   lastUpdated: 0,
 };
 
@@ -11,6 +15,8 @@ const pricesReducer = (state = initialState, action) => {
         ...state,
         prices: action.payload.prices,
         apy: action.payload.apy,
+        ppfs: action.payload.ppfs,
+        byNetworkAddress: action.payload.byNetworkAddress,
         lastUpdated: action.payload.lastUpdated,
       };
     default:

--- a/src/features/winners/apollo/draws.js
+++ b/src/features/winners/apollo/draws.js
@@ -28,13 +28,13 @@ const query = gql`
       prizePool {
         address
       }
-      awards {
-        token
-        amount
-      }
       winners {
         address
         staked
+        awards {
+          token
+          amount
+        }
       }
     }
   }

--- a/src/features/winners/apollo/total.js
+++ b/src/features/winners/apollo/total.js
@@ -36,7 +36,7 @@ export const useTotalPrizeValue = function () {
   });
 
   const prizePools = !loading && !error ? data?.prizePools : null;
-  const prices = useSelector(state => state.pricesReducer.prices);
+  const prices = useSelector(state => state.pricesReducer.byNetworkAddress[network]);
 
   const total = useMemo(() => {
     let sum = new BigNumber(0);
@@ -47,7 +47,7 @@ export const useTotalPrizeValue = function () {
           const tokenData = tokensByNetworkAddress[network]?.[token.toLowerCase()];
           if (tokenData) {
             const numericAmount = byDecimals(amount, tokenData.decimals);
-            const price = new BigNumber(prices[tokenData.oracleId] || 0);
+            const price = new BigNumber(prices[tokenData.address] || 0);
             sum = sum.plus(numericAmount.multipliedBy(price));
           } else {
             console.error(`No token for ${token} on ${network} found`);

--- a/src/features/winners/components/Draw/Draw.js
+++ b/src/features/winners/components/Draw/Draw.js
@@ -8,7 +8,7 @@ import { tokensByNetworkAddress } from '../../../../config/tokens';
 import { DrawStat } from '../../../../components/DrawStat';
 import { TransListJoin } from '../../../../components/TransListJoin';
 import { byDecimals, formatDecimals } from '../../../../helpers/format';
-import { formatAddressShort } from '../../../../helpers/utils';
+import { formatAddressShort, getUnderylingToken } from '../../../../helpers/utils';
 import { ErrorOutline } from '@material-ui/icons';
 import BigNumber from 'bignumber.js';
 import clsx from 'clsx';
@@ -18,83 +18,111 @@ import { Translate } from '../../../../components/Translate';
 const useStyles = makeStyles(styles);
 const network = 'bsc';
 
-const useTotalPrizeValue = function (winnings, numberOfWinners) {
+const useTotalPrizeValue = function (winners) {
   return useMemo(() => {
     let sum = 0;
 
-    for (const { value } of winnings) {
-      sum += value * numberOfWinners;
+    for (const winner of winners) {
+      for (const award of winner.awards) {
+        sum += award.value;
+      }
     }
 
     return sum;
-  }, [winnings, numberOfWinners]);
+  }, [winners]);
 };
 
-const useDrawSponsor = function (depositTokenAddress, ticketTokenAddress, awards) {
+const useDrawSponsor = function (depositTokenAddress, ticketTokenAddress, winners) {
   return useMemo(() => {
     const depositTokenAddressLower = depositTokenAddress.toLowerCase();
     const ticketTokenAddressLower = ticketTokenAddress.toLowerCase();
 
     // Return first token which isn't base token
-    for (const { token } of awards) {
-      const tokenAddress = token.toLowerCase();
-      if (tokenAddress !== depositTokenAddressLower && tokenAddress !== ticketTokenAddressLower) {
-        return tokensByNetworkAddress[network]?.[tokenAddress]?.symbol;
+    for (const winner of winners) {
+      for (const { token } of winner.awards) {
+        const tokenAddress = token.toLowerCase();
+        if (tokenAddress !== depositTokenAddressLower && tokenAddress !== ticketTokenAddressLower) {
+          return tokensByNetworkAddress[network]?.[tokenAddress]?.symbol;
+        }
       }
     }
 
     return null;
-  }, [depositTokenAddress, ticketTokenAddress, awards]);
+  }, [depositTokenAddress, ticketTokenAddress, winners]);
 };
 
-const useNormalizedWinnings = function (awards, drawToken, ticketAddress, ppfs) {
+function normalizeWinnings(awards, drawToken, ticketAddress, ticketPPFS, prices) {
+  const tokens = {
+    [drawToken]: {
+      symbol: drawToken,
+      amount: new BigNumber(0),
+      value: new BigNumber(0),
+    },
+  };
+
+  for (const { token, amount } of awards) {
+    const tokenData = tokensByNetworkAddress[network]?.[token.toLowerCase()];
+    if (tokenData) {
+      let numericAmount = byDecimals(amount, tokenData.decimals);
+
+      // Handle PPFS for reward in pot tickets
+      if (token.toLowerCase() === ticketAddress.toLowerCase()) {
+        const pricePerFullShare = byDecimals(ticketPPFS || '1000000000000000000', 18);
+        numericAmount = numericAmount.multipliedBy(pricePerFullShare);
+      }
+
+      const underlyingToken = getUnderylingToken(tokenData);
+      const price = new BigNumber(prices[underlyingToken.oracleId] || 0);
+      const totalPrice = numericAmount.multipliedBy(price);
+      const symbol = underlyingToken.symbol;
+
+      if (symbol in tokens) {
+        tokens[symbol].amount = tokens[symbol].amount.plus(numericAmount);
+        tokens[symbol].value = tokens[symbol].value.plus(totalPrice);
+      } else {
+        tokens[symbol] = {
+          symbol: symbol,
+          amount: numericAmount,
+          value: totalPrice,
+        };
+      }
+    } else {
+      console.error(`No token for ${token} on ${network} found`);
+    }
+  }
+
+  return Object.values(tokens).map(token => ({
+    symbol: token.symbol,
+    amount: token.amount.toNumber(),
+    value: token.value.toNumber(),
+  }));
+}
+
+function normalizeStaked(stakedAmount, ticketAddress, ticketPPFS, prices) {
+  const ticketToken = tokensByNetworkAddress[network][ticketAddress.toLowerCase()];
+  const underlyingToken = getUnderylingToken(ticketToken);
+  const price = new BigNumber(prices[underlyingToken.oracleId] || 0);
+  const pricePerFullShare = byDecimals(ticketPPFS || '1000000000000000000', 18);
+  const numericAmount = byDecimals(stakedAmount, ticketToken.decimals)
+    .multipliedBy(pricePerFullShare)
+    .multipliedBy(ticketToken.stakedMultiplier);
+
+  return {
+    staked: numericAmount.toNumber(),
+    stakedValue: numericAmount.multipliedBy(price).toNumber(),
+  };
+}
+
+const useNormalizedWinners = function (winners, drawToken, ticketAddress, ticketPPFS) {
   const prices = useSelector(state => state.pricesReducer.prices);
 
   return useMemo(() => {
-    const tokens = {
-      [drawToken]: {
-        symbol: drawToken,
-        amount: new BigNumber(0),
-        value: new BigNumber(0),
-      },
-    };
-
-    for (const { token, amount } of awards) {
-      const tokenData = tokensByNetworkAddress[network]?.[token.toLowerCase()];
-      if (tokenData) {
-        let numericAmount = byDecimals(amount, tokenData.decimals);
-
-        // Handle PPFS for reward in pot tickets
-        if (token.toLowerCase() === ticketAddress.toLowerCase()) {
-          const pricePerFullShare = byDecimals(ppfs || '1000000000000000000', 18);
-          numericAmount = numericAmount.multipliedBy(pricePerFullShare);
-        }
-
-        const price = new BigNumber(prices[tokenData.oracleId] || 0);
-        const totalPrice = numericAmount.multipliedBy(price);
-        const symbol = tokenData.underlyingToken || tokenData.symbol;
-
-        if (symbol in tokens) {
-          tokens[symbol].amount = tokens[symbol].amount.plus(numericAmount);
-          tokens[symbol].value = tokens[symbol].value.plus(totalPrice);
-        } else {
-          tokens[symbol] = {
-            symbol: symbol,
-            amount: numericAmount,
-            value: totalPrice,
-          };
-        }
-      } else {
-        console.error(`No token for ${token} on ${network} found`);
-      }
-    }
-
-    return Object.values(tokens).map(token => ({
-      symbol: token.symbol,
-      amount: token.amount.toNumber(),
-      value: token.value.toNumber(),
+    return winners.map(winner => ({
+      ...winner,
+      awards: normalizeWinnings(winner.awards, drawToken, ticketAddress, ticketPPFS, prices),
+      ...normalizeStaked(winner.staked, ticketAddress, ticketPPFS, prices),
     }));
-  }, [awards, prices, drawToken, ppfs, ticketAddress]);
+  }, [winners, prices, drawToken, ticketPPFS, ticketAddress]);
 };
 
 const Title = memo(function ({ name }) {
@@ -119,9 +147,11 @@ const ValueWon = memo(function ({ currency, amount }) {
   );
 });
 
-const WonTokens = memo(function ({ winnings }) {
+const WonTokens = memo(function ({ winners }) {
   const classes = useStyles();
-  const allTokens = winnings.map(winning => winning.symbol);
+  const allTokens = new Set();
+
+  winners.forEach(winner => winner.awards.forEach(award => allTokens.add(award.symbol)));
 
   return (
     <div className={classes.wonTotalTokens}>
@@ -143,10 +173,10 @@ const Players = memo(function ({ players }) {
   });
 });
 
-const PrizePerWinner = memo(function ({ winnings }) {
+const PrizePerWinner = memo(function ({ winners }) {
   const classes = useStyles();
 
-  return Object.values(winnings).map(prize => {
+  return Object.values(winners[0].awards).map(prize => {
     return (
       <div key={prize.symbol} className={classes.prizePerWinner}>
         <span className={classes.perWinnerToken}>
@@ -158,31 +188,25 @@ const PrizePerWinner = memo(function ({ winnings }) {
   });
 });
 
-const Winners = memo(function ({ network, tokenAddress, winners, ticketAddress }) {
+const Winners = memo(function ({ network, tokenAddress, winners }) {
   const { t } = useTranslation();
   const classes = useStyles();
-  const prices = useSelector(state => state.pricesReducer.prices);
   const tokenData = tokensByNetworkAddress[network]?.[tokenAddress.toLowerCase()];
-  const price = prices[tokenData.oracleId] || 0;
-  const tokenDecimals = tokenData.decimals;
-  const ticketData = tokensByNetworkAddress[network]?.[ticketAddress.toLowerCase()];
-  const ticketToStaked = ticketData.stakedMultiplier;
 
   const sortedWinners = useMemo(() => {
     const entries = winners.map((winner, index) => {
-      const staked = byDecimals(winner.staked, tokenDecimals).multipliedBy(ticketToStaked);
-      const value = staked.multipliedBy(price);
-
       return {
         id: winner.address + index,
-        staked: staked.toNumber(),
-        value: value.toNumber(),
+        staked: winner.staked,
+        value: winner.stakedValue,
         address: winner.address,
       };
     });
 
     return entries.sort((a, b) => (a.staked > b.staked) - (a.staked < b.staked));
-  }, [winners, price, tokenDecimals, ticketToStaked]);
+  }, [winners]);
+
+  console.log(sortedWinners);
 
   return (
     <Grid container spacing={2} className={classes.rowWinners}>
@@ -227,14 +251,15 @@ const UserWonDraw = memo(function ({ winners }) {
 
 export const Draw = function ({ draw }) {
   const classes = useStyles();
-  const winnings = useNormalizedWinnings(
-    draw.awards,
+  const winners = useNormalizedWinners(
+    draw.winners,
     draw.pot.token,
     draw.pot.rewardAddress,
     draw.ppfs
   );
-  const totalPrizeValue = useTotalPrizeValue(winnings, draw.winners.length);
-  const sponsorToken = useDrawSponsor(draw.pot.tokenAddress, draw.pot.rewardAddress, draw.awards);
+  console.log(draw.pot.id, winners);
+  const totalPrizeValue = useTotalPrizeValue(winners);
+  const sponsorToken = useDrawSponsor(draw.pot.tokenAddress, draw.pot.rewardAddress, draw.winners);
 
   return (
     <Card variant="purpleMid">
@@ -249,7 +274,7 @@ export const Draw = function ({ draw }) {
         <Grid item xs={8}>
           <Title name={draw.pot.name} />
           <ValueWon currency="$" amount={totalPrizeValue} />
-          <WonTokens winnings={winnings} />
+          <WonTokens winners={winners} />
         </Grid>
       </Grid>
       <UserWonDraw winners={draw.winners} />
@@ -266,7 +291,7 @@ export const Draw = function ({ draw }) {
         </Grid>
         <Grid item xs={12}>
           <DrawStat i18nKey="winners.prizePerWinner">
-            <PrizePerWinner winnings={winnings} />
+            <PrizePerWinner winners={winners} />
           </DrawStat>
         </Grid>
       </Grid>
@@ -275,8 +300,7 @@ export const Draw = function ({ draw }) {
           <Winners
             network={draw.pot.network}
             tokenAddress={draw.pot.tokenAddress}
-            ticketAddress={draw.pot.rewardAddress}
-            winners={draw.winners}
+            winners={winners}
           />
           <Link
             href={`https://bscscan.com/tx/${draw.txHash}`}

--- a/src/helpers/hooks.js
+++ b/src/helpers/hooks.js
@@ -91,7 +91,7 @@ export function useTokenEarned(id, token, tokenDecimals) {
 export function useTokenAddressPrice(address, network = 'bsc') {
   const tokenData = tokensByNetworkAddress[network]?.[address.toLowerCase()];
   return useSelector(state =>
-    tokenData ? state.pricesReducer.prices[tokenData.oracleId] || 0 : 0
+    tokenData ? state.pricesReducer.byNetworkAddress[tokenData.network][tokenData.address] || 0 : 0
   );
 }
 

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1,5 +1,6 @@
 import { config } from '../config/config';
 import BigNumber from 'bignumber.js';
+import { tokensByNetworkSymbol } from '../config/tokens';
 
 let trimReg = /(^\s*)|(\s*$)/g;
 
@@ -108,4 +109,16 @@ export function getFairplayFeePercent(secondsRemaining, days = 10, fee = 0.05) {
   }
 
   return 0;
+}
+
+export function getApiCacheBuster() {
+  return Math.trunc(Date.now() / (1000 * 60));
+}
+
+export function getUnderylingToken(token) {
+  while (token.underlyingToken) {
+    token = tokensByNetworkSymbol[token.network][token.underlyingToken];
+  }
+
+  return token;
 }


### PR DESCRIPTION
Closes #348 

### For new Ziggy pot:
- Winning token amounts / values; taking in to account draw-time PPFS for moonTicketPOTSv3
- Staked token amounts / values;  taking in to account draw-time PPFS for moonTicketPOTSv3
- Overall total prizes won, taking in to account **live** PPFS for moonTicketPOTSv3

### For all draws
- Calculate total prize won per draw based on each winners winnings, not the first winners' winnings multiplied by number of winners.

### Prices
- Fetch PPFS for tokens of type 'moo' - stored in `pricesReducer.ppfs[network][address]`
- Use token types/ppfs/underlying token to calculate a price for each token in tokens/bsc.json - stored in `pricesReducer.byNetworkAddress[network][address]`
- Fetch prices, lp prices, apy and ppfs in parallel