### PR TITLE
Fix APY + Prize Projections when underlying vault has tradingApr

### DIFF
--- a/src/config/vault/bsc.json
+++ b/src/config/vault/bsc.json
@@ -19,6 +19,9 @@
     "duration": 14,
     "fairplayDuration": 10,
     "fairplayTicketFee": 0.025,
+    "interestBreakdown": {
+      "interest": 100
+    },
     "status": "active",
     "supportsAutocompound": true,
     "supportsClaimAllBonuses": false,


### PR DESCRIPTION
Closes #277 

Player APY: Share of farm/vault interest + 100% of trading interest
Prize Projections: Share of farm/vault interest only as player keeps 100% of trading APY

This applies to all LP pots as well as the stables pot (and any future belt pots):
Prize predictions are down, player APY is up